### PR TITLE
Add patch for The Legend of Zelda: Breath of the Wild 1.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,6 +457,7 @@ DETAILS contains links to documents explaining why patch is necessary, possible 
 | The Legend of Heroes: Trails into Reverie | `01008CB0156BC000` | `A3E80F5FE073639D` ([✅](SaltySD/plugins/FPSLocker/patches/01008CB0156BC000/A3E80F5FE073639D.yaml), v2, 1.0.2) <br> `BC3750610F6BCA5C` ([✅](SaltySD/plugins/FPSLocker/patches/01008CB0156BC000/BC3750610F6BCA5C.yaml), v3, 1.0.3) | 🔴 |  |
 | The Legend of Heroes: Trails of Cold Steel III | `01005420101DA000` | `134EC3D8BE75126F` ([✅](SaltySD/plugins/FPSLocker/patches/01005420101DA000/134EC3D8BE75126F.yaml), v1, 1.0.1) | 🔴 |  |
 | The Legend of Heroes: Trails of Cold Steel IV | `0100D3C010DE8000` | `59159483CF88330F` ([✅](SaltySD/plugins/FPSLocker/patches/0100D3C010DE8000/59159483CF88330F.yaml), v3, 1.0.3) | 🔴 |  |
+| The Legend of Zelda: Breath of the Wild | `01007EF00011E000` | `8E9978D50BDD20B4` ([✅](SaltySD/plugins/FPSLocker/patches/01007EF00011E000/8E9978D50BDD20B4.yaml), v12, 1.6.0) | 🟡 |  |
 | The LEGO Movie 2 - Videogame | `0100A4400BE74000` | `BAC1309DDF75B14D` (◯, v3, 1.0.3) | 🟢 |  |
 | The LEGO NINJAGO Movie Video Game | `01000CE002072000` | `346959B36CD9F14D` (◯, v3, 1.0.3) | 🟢 |  |
 | The Outer Worlds | `0100626011656000` | `761CD556AB357C87` ([✅](SaltySD/plugins/FPSLocker/patches/0100626011656000/761CD556AB357C87.yaml), v5, 1.0.5) | 🔵 | [LINK](Methodology/The%20Outer%20Worlds) 

--- a/SaltySD/plugins/FPSLocker/patches/01007EF00011E000/8E9978D50BDD20B4.yaml
+++ b/SaltySD/plugins/FPSLocker/patches/01007EF00011E000/8E9978D50BDD20B4.yaml
@@ -117,6 +117,12 @@ MASTER_WRITE:
     main_offset: 0xD3EF90
     value_type: uint32
     value: 0x144FAB22
+  # Fix weird ragdolls physics calculation
+  -
+    type: bytes
+    main_offset: 0x1618480
+    value_type: uint32
+    value: 0x1E2E1009
 15FPS:
   # DR GPU Time Factor
   -

--- a/SaltySD/plugins/FPSLocker/patches/01007EF00011E000/8E9978D50BDD20B4.yaml
+++ b/SaltySD/plugins/FPSLocker/patches/01007EF00011E000/8E9978D50BDD20B4.yaml
@@ -65,19 +65,20 @@ MASTER_WRITE:
     main_offset: 0x1821588
     value_type: uint32
     value: 0xBC5FC100
-  # Implement dynamic speed, min limited to 1/120 ms, max to 1/15ms
+  # Fix weird ragdolls physics calculation
   -
     type: bytes
-    main_offset: 0x124EFC8
+    main_offset: 0x1618480
     value_type: uint32
-    value: 0x143B6AF7
+    value: 0x1E2E1009
+  # CODE CAVE
   -
     type: bytes
     main_offset: 0x2129BA4
     value_type: uint32
     value: 
+      - 0xF90003E1
       - 0xD63F0100
-      - 0xD503201F
       - 0x97FFF935
       - 0x97FFF99C
       - 0x900061E1
@@ -100,29 +101,75 @@ MASTER_WRITE:
       - 0xF940B800
       - 0x1E624000
       - 0xBD003000
-      - 0x17C494F2
+      - 0x14000015
       - 0xEB02001F
       - 0x54FFFEAA
       - 0xAA0203E0
       - 0x17FFFFF3
-    # Fix issue with hardcoding some aiming parameters to speed per frame
       - 0xBC68D920
       - 0xB0005FA9
       - 0xF940B929
       - 0xBD403121
       - 0x1E210800
       - 0x17B054DA
+      - 0x97FFF99C
+      - 0x900061E0
+      - 0x52800021
+      - 0xB90C9001
+      - 0x17BA1888
+      - 0x97FFF997
+      - 0x900061E0
+      - 0x52800041
+      - 0xB90C9001
+      - 0x17BA1677
+      - 0x900061E0
+      - 0xB94C9000
+      - 0x340000E0
+      - 0x370800E0
+      - 0xF94003E0
+      - 0x12800021
+      - 0xD0006028
+      - 0xF9406908
+      - 0xD63F0100
+      - 0x17C494D4
+      - 0x900061E1
+      - 0xB94C9421
+      - 0xF94003E0
+      - 0xD0006028
+      - 0xF9406908
+      - 0xD63F0100
+      - 0x900061E0
+      - 0xB90C901F
+      - 0x17C494CB
+  # Connect dynamic speed to game's code
+  -
+    type: bytes
+    main_offset: 0x124EFC8
+    value_type: uint32
+    value: 0x143B6AF7
+  # Connect fixing aiming to game's code
   -
     type: bytes
     main_offset: 0xD3EF90
     value_type: uint32
     value: 0x144FAB22
-  # Fix weird ragdolls physics calculation
+  # Connect AMV FPS locking
   -
     type: bytes
-    main_offset: 0x1618480
+    main_offset: 0xFAFE5C
     value_type: uint32
-    value: 0x1E2E1009
+    value: 0x1445E775
+  -
+    type: bytes
+    main_offset: 0xFAF62C
+    value_type: uint32
+    value: 0x1445E986
+  # Default interval
+  -
+    type: bytes
+    main_offset: 0x2D65C94
+    value_type: int32
+    value: -2
 15FPS:
   # DR GPU Time Factor
   -
@@ -130,6 +177,12 @@ MASTER_WRITE:
     address: [MAIN, 0x2D65C80]
     value_type: float
     value: 0.0005
+  # DR GPU Time Factor
+  -
+    type: write
+    address: [MAIN, 0x2D65C94]
+    value_type: int32
+    value: -4
 20FPS:
   # DR GPU Time Factor
   -
@@ -137,6 +190,11 @@ MASTER_WRITE:
     address: [MAIN, 0x2D65C80]
     value_type: float
     value: 0.000667
+  -
+    type: write
+    address: [MAIN, 0x2D65C94]
+    value_type: int32
+    value: -3
 25FPS:
   # DR GPU Time Factor
   -
@@ -144,6 +202,11 @@ MASTER_WRITE:
     address: [MAIN, 0x2D65C80]
     value_type: float
     value: 0.000834
+  -
+    type: write
+    address: [MAIN, 0x2D65C94]
+    value_type: int32
+    value: -2
 30FPS:
   # DR GPU Time Factor (default value)
   -
@@ -151,6 +214,11 @@ MASTER_WRITE:
     address: [MAIN, 0x2D65C80]
     value_type: float
     value: 0.001
+  -
+    type: write
+    address: [MAIN, 0x2D65C94]
+    value_type: int32
+    value: -2
 35FPS:
   # DR GPU Time Factor
   -
@@ -158,6 +226,11 @@ MASTER_WRITE:
     address: [MAIN, 0x2D65C80]
     value_type: float
     value: 0.00117
+  -
+    type: write
+    address: [MAIN, 0x2D65C94]
+    value_type: int32
+    value: -1
 40FPS:
   # DR GPU Time Factor
   -
@@ -165,6 +238,11 @@ MASTER_WRITE:
     address: [MAIN, 0x2D65C80]
     value_type: float
     value: 0.00134
+  -
+    type: write
+    address: [MAIN, 0x2D65C94]
+    value_type: int32
+    value: -1
 45FPS:
   # DR GPU Time Factor
   -
@@ -172,6 +250,11 @@ MASTER_WRITE:
     address: [MAIN, 0x2D65C80]
     value_type: float
     value: 0.0015
+  -
+    type: write
+    address: [MAIN, 0x2D65C94]
+    value_type: int32
+    value: -1
 50FPS:
   # DR GPU Time Factor
   -
@@ -179,6 +262,11 @@ MASTER_WRITE:
     address: [MAIN, 0x2D65C80]
     value_type: float
     value: 0.00167
+  -
+    type: write
+    address: [MAIN, 0x2D65C94]
+    value_type: int32
+    value: -1
 55FPS:
   # DR GPU Time Factor
   -
@@ -186,6 +274,11 @@ MASTER_WRITE:
     address: [MAIN, 0x2D65C80]
     value_type: float
     value: 0.00184
+  -
+    type: write
+    address: [MAIN, 0x2D65C94]
+    value_type: int32
+    value: -1
 60FPS:
   # DR GPU Time Factor
   -
@@ -193,3 +286,8 @@ MASTER_WRITE:
     address: [MAIN, 0x2D65C80]
     value_type: float
     value: 0.002
+  -
+    type: write
+    address: [MAIN, 0x2D65C94]
+    value_type: int32
+    value: -1

--- a/SaltySD/plugins/FPSLocker/patches/01007EF00011E000/8E9978D50BDD20B4.yaml
+++ b/SaltySD/plugins/FPSLocker/patches/01007EF00011E000/8E9978D50BDD20B4.yaml
@@ -1,0 +1,177 @@
+# The Legend of Zelda: Breath of the Wild 1.6.0
+# BID: 8E9978D50BDD20B4
+
+unsafeCheck: true
+
+MASTER_WRITE:
+  # Remove double buffer
+  -
+    type: bytes
+    main_offset: 0xE557D4
+    value_type: uint32
+    value: 0x52800029
+  -
+    type: bytes
+    main_offset: 0xE557E0
+    value_type: uint32
+    value: 
+      - 0x3902F6A9
+      - 0x52800069
+      - 0xD503201F
+  # Block updating time struct when in menus
+  -
+    type: bytes
+    main_offset: 0xF8BA58
+    value_type: uint32
+    value: 0xD503201F
+  # Change pointer of GPU time factor for DR calculations to MAIN + 0x2D65C80
+  -
+    type: bytes
+    main_offset: 0x150AB50
+    value_type: uint32
+    value: 
+      - 0xF000C2C8
+      - 0xBD4C8101
+  # Default DR GPU time factor
+  -
+    type: bytes
+    main_offset: 0x2D65C80
+    value_type: float
+    value: 0.001
+  # Pass Global Engine Speed to UI speed
+  -
+    type: bytes
+    main_offset: 0x18522EC
+    value_type: uint32
+    value: 
+     - 0xD503201F
+     - 0xD503201F
+     - 0xD503201F
+     - 0xD503201F
+     - 0xD503201F
+     - 0xBC5FC100
+  # Pass Global Engine Speed to some other speed
+  -
+    type: bytes
+    main_offset: 0x1821568
+    value_type: uint32
+    value: 
+     - 0xD503201F
+     - 0xD503201F
+     - 0xD503201F
+     - 0xD503201F
+  -
+    type: bytes
+    main_offset: 0x1821588
+    value_type: uint32
+    value: 0xBC5FC100
+  # Implement dynamic speed, min locked to 1/120 ms, max to 1/15ms
+  -
+    type: bytes
+    main_offset: 0x124EFC8
+    value_type: uint32
+    value: 0x143B6AF7
+  -
+    type: bytes
+    main_offset: 0x2129BA4
+    value_type: uint32
+    value: 
+      - 0xD63F0100
+      - 0xD503201F
+      - 0x97FFF935
+      - 0x97FFF99C
+      - 0x900061E1
+      - 0xF9464422
+      - 0xF9064420
+      - 0xCB020000
+      - 0x528502A2
+      - 0x72A00FE2
+      - 0x52881541
+      - 0x72A07F21
+      - 0xEB01001F
+      - 0x5400018D
+      - 0xAA0103E0
+      - 0x1E601000
+      - 0x1E630001
+      - 0x1E630022
+      - 0x1E621821
+      - 0x1E610800
+      - 0xB0005FA0
+      - 0xF940B800
+      - 0x1E624000
+      - 0xBD003000
+      - 0x17C494F2
+      - 0xEB02001F
+      - 0x54FFFEAA
+      - 0xAA0203E0
+      - 0x17FFFFF3
+15FPS:
+  # DR GPU Time Factor
+  -
+    type: write
+    address: [MAIN, 0x2D65C80]
+    value_type: float
+    value: 0.0005
+20FPS:
+  # DR GPU Time Factor
+  -
+    type: write
+    address: [MAIN, 0x2D65C80]
+    value_type: float
+    value: 0.000667
+25FPS:
+  # DR GPU Time Factor
+  -
+    type: write
+    address: [MAIN, 0x2D65C80]
+    value_type: float
+    value: 0.000834
+30FPS:
+  # DR GPU Time Factor (default value)
+  -
+    type: write
+    address: [MAIN, 0x2D65C80]
+    value_type: float
+    value: 0.001
+35FPS:
+  # DR GPU Time Factor
+  -
+    type: write
+    address: [MAIN, 0x2D65C80]
+    value_type: float
+    value: 0.00117
+40FPS:
+  # DR GPU Time Factor
+  -
+    type: write
+    address: [MAIN, 0x2D65C80]
+    value_type: float
+    value: 0.00134
+45FPS:
+  # DR GPU Time Factor
+  -
+    type: write
+    address: [MAIN, 0x2D65C80]
+    value_type: float
+    value: 0.0015
+50FPS:
+  # DR GPU Time Factor
+  -
+    type: write
+    address: [MAIN, 0x2D65C80]
+    value_type: float
+    value: 0.00167
+55FPS:
+  # DR GPU Time Factor
+  -
+    type: write
+    address: [MAIN, 0x2D65C80]
+    value_type: float
+    value: 0.00184
+60FPS:
+  # DR GPU Time Factor
+  -
+    type: write
+    address: [MAIN, 0x2D65C80]
+    value_type: float
+    value: 0.002

--- a/SaltySD/plugins/FPSLocker/patches/01007EF00011E000/8E9978D50BDD20B4.yaml
+++ b/SaltySD/plugins/FPSLocker/patches/01007EF00011E000/8E9978D50BDD20B4.yaml
@@ -65,7 +65,7 @@ MASTER_WRITE:
     main_offset: 0x1821588
     value_type: uint32
     value: 0xBC5FC100
-  # Implement dynamic speed, min locked to 1/120 ms, max to 1/15ms
+  # Implement dynamic speed, min limited to 1/120 ms, max to 1/15ms
   -
     type: bytes
     main_offset: 0x124EFC8
@@ -105,6 +105,18 @@ MASTER_WRITE:
       - 0x54FFFEAA
       - 0xAA0203E0
       - 0x17FFFFF3
+    # Fix issue with hardcoding some aiming parameters to speed per frame
+      - 0xBC68D920
+      - 0xB0005FA9
+      - 0xF940B929
+      - 0xBD403121
+      - 0x1E210800
+      - 0x17B054DA
+  -
+    type: bytes
+    main_offset: 0xD3EF90
+    value_type: uint32
+    value: 0x144FAB22
 15FPS:
   # DR GPU Time Factor
   -


### PR DESCRIPTION
Still WIP. Most stuff is done, known issues (only crucial for gameplay are planned to be fixed):

- [x] AMV cutscenes speed is tied to framerate (it will be fixed only for 30 FPS or more by locking interval to 30 FPS) 
- [x] When using powers, vertical aiming has fixed degrees per frame speed 
- speed of cursor on the map has also fixed speed per frame
- Period between going from press action to hold action in menus is tied to framerate 
- When accessing weapons menu with d-pad, at uneven framerates gradual applying of vignette doesn't have enough time to not show completely black on whole screen, resulting in background being black for one frame, higher framerate means higher chance of it occurring.
- in real time cutscenes what looks like instantenous camera change is in fact not instantenous, which shows up at higher framerates as mid-frame between two cuts

Didn't found any other issue that exist in other existing 60 FPS mods/cheats for this game, like not working ragdolls. Before releasing I need only to check if Blood Moon timer is not screwed.

Additions:
- Forcing game to use triple buffer
- Gameplay and UI speeds are now dynamically calculated