### PR TITLE
Add patch for Ni no Kuni: Wrath of the White Witch 1.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,7 +407,7 @@ DETAILS contains links to documents explaining why patch is necessary, possible 
 | Never Alone (Kisima Ingitchuna) | `0100A6B01712C000` | `B489970C5C8E79A7` (❌, v2, 1.0.2) | 🔵 |  |
 | New Super Lucky's Tale | `010017700B6C2000` | `14872049185C584C` (◯, v3, 1.5.9) | 🟢 |  |
 | New Tales from the Borderlands | `01002B7013440000` | `A19E113723E5C32E` ([✅](SaltySD/plugins/FPSLocker/patches/01002B7013440000/A19E113723E5C32E.yaml), v2, 1.0.2) | 🔴 | [LINK](Methodology/New%20Tales%20from%20the%20Borderlands) |
-| Ni no Kuni: Wrath of the White Witch | `0100E5600D446000` | `C32B29CB5FBA96D9` (❌, v2, 1.0.2) | 🟡 |  |
+| Ni no Kuni: Wrath of the White Witch | `0100E5600D446000` | `C32B29CB5FBA96D9` ([✅](SaltySD/plugins/FPSLocker/patches/0100E5600D446000/C32B29CB5FBA96D9.yaml), v2, 1.0.2) | 🟡 |  |
 | Nickelodeon All-Star Brawl 2 | `010010701AFB2000` | `8C1B07DDCA5A20B0` (◯, v13, 1.13.0) | 🟢 |  |
 | NieR:Automata `ASIA` | `0100B8E016F76000` | `992787E2B5425994` ([✅](SaltySD/plugins/FPSLocker/patches/0100B8E016F76000/992787E2B5425994.yaml), v1, 1.0.2) | 🔵 |  |
 | NieR:Automata `GLOBAL` | `010056B015FE8000` | `E43525F22282A477` ([✅](SaltySD/plugins/FPSLocker/patches/010056B015FE8000/E43525F22282A477.yaml), v1, 1.0.2) | 🔵 |  |

--- a/SaltySD/plugins/FPSLocker/patches/0100E5600D446000/C32B29CB5FBA96D9.yaml
+++ b/SaltySD/plugins/FPSLocker/patches/0100E5600D446000/C32B29CB5FBA96D9.yaml
@@ -1,0 +1,22 @@
+# Ni no Kuni: Wrath of the White Witch 1.0.2
+# BID: C32B29CB5FBA96D9
+
+unsafeCheck: true
+
+ALL_FPS:
+  # Game speed value
+  -
+    type: evaluate_write
+    address: [MAIN, 0x2218B44, 0x20]
+    value_type: float
+    value: "1 / FPS_TARGET"
+  # Block prerendered cutscenes to 30 FPS
+  -
+    type: evaluate_compare
+    compare_address: [MAIN, 0x1728B58]
+    compare_type: "!="
+    compare_value_type: uint32
+    compare_value: 0
+    address: [MAIN]
+    value_type: refresh_rate
+    value: 60


### PR DESCRIPTION
Requires SaltyNX 1.0.5+ to properly support cutscenes at sub 60 Hz.