### PR TITLE
Fix IDs for Shin Megami Tensei V

### DIFF
--- a/SaltySD/plugins/FPSLocker/patches/010063B012DC6000/68FED4970010ACF3.yaml
+++ b/SaltySD/plugins/FPSLocker/patches/010063B012DC6000/68FED4970010ACF3.yaml
@@ -1,10 +1,8 @@
-# SHIN MEGAMI TENSEI V 1.0.2
+# SHIN MEGAMI TENSEI V `The Americas` 1.0.2
 # BID: 68FED4970010ACF3
 
-unsafeCheck: true
-
 ALL_FPS:
-  # r.DynamicRes.FrameTimeBudget (1000/FPS) cutted to 2 decimals
+  # r.DynamicRes.FrameTimeBudget
   -
     type: evaluate_write
     address: [MAIN, 0x75F81D0, 0]

--- a/SaltySD/plugins/FPSLocker/patches/010063B012DC6000/68FED4970010ACF3.yaml
+++ b/SaltySD/plugins/FPSLocker/patches/010063B012DC6000/68FED4970010ACF3.yaml
@@ -1,0 +1,21 @@
+# SHIN MEGAMI TENSEI V 1.0.2
+# BID: 68FED4970010ACF3
+
+unsafeCheck: true
+
+ALL_FPS:
+  # r.DynamicRes.FrameTimeBudget (1000/FPS) cutted to 2 decimals
+  -
+    type: evaluate_write
+    address: [MAIN, 0x75F81D0, 0]
+    value_type: float
+    value: ["TruncDec(FRAMETIME_TARGET, 2)", "TruncDec(FRAMETIME_TARGET, 2)"]
+  # t.MaxFPS
+  -
+    type: evaluate_write
+    address: [MAIN, 0x7621D70, 0]
+    value_type: float
+    value: [FPS_LOCK_TARGET, FPS_LOCK_TARGET]
+  -
+    type: block
+    what: timing


### PR DESCRIPTION
Fixed IDs for Shin Megami Tensei V version 1.0.2. Tried to load the patches from my switch, but there were IDs mismatch. Can ask me on Discord (same username) for a screenshot of the IDs obtained from FPSLocker. My version of the game is the North American version.