### PR TITLE
Add patch for Metal Gear Solid 4: Guns of the Patriots `JPN` 1.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -686,6 +686,7 @@ PATCH AVAILABILITY<br>
 | Metal Gear Solid 2: Sons of Liberty `JPN` | `0100EE8019534001` | `818EA1592F5B931A` (❌, v8, 2.0.1) | [⚔️](#⚔️)[⏱️](#⏱️)[🖥️](#🖥️) |
 | Metal Gear Solid 3: Snake Eater | `010047F01AA10001` | `C7F276F193E4DE4C` (❌, v12, 3.0.0) | [⚔️](#⚔️)[⏱️](#⏱️)[🖥️](#🖥️)[🔢](#🔢) |
 | Metal Gear Solid 3: Snake Eater `JPN` | `0100099019536001` | `C7F276F193E4DE4C` (❌, v9, 3.0.0) | [⚔️](#⚔️)[⏱️](#⏱️)[🖥️](#🖥️)[🔢](#🔢) |
+| Metal Gear Solid 4: Guns of the Patriots | `0100D0B01C4F4002` | `3F3713A6149C24FA` ([✅](SaltySD/plugins/FPSLocker/patches/0100D0B01C4F4002/3F3713A6149C24FA.yaml), v4, 1.4.1) | ~~[🔐](#🔐)[📏](#📏)~~ |
 | Metamorphosis | `010055200E87E000` | `9F1B5FB4C53E321F` ([✅](SaltySD/plugins/FPSLocker/patches/010055200E87E000/9F1B5FB4C53E321F.yaml), v1, 1.0.1) | ~~[🔐](#🔐)[📏](#📏)[🔧](#🔧)~~ |
 | Metro 2033 Redux | `0100D4900E82C000` | `85C362CC9790F0ED` ([✅](SaltySD/plugins/FPSLocker/patches/0100D4900E82C000/85C362CC9790F0ED.yaml), v0, 1.0.0) | ~~[📏](#📏)~~ |
 | Metro: Last Light Redux | `0100F0400E850000` | `85C362CC9790F0ED` ([✅](SaltySD/plugins/FPSLocker/patches/0100F0400E850000/85C362CC9790F0ED.yaml), v0, 1.0.0) | ~~[📏](#📏)~~ |

--- a/SaltySD/plugins/FPSLocker/patches/0100D0B01C4F4002/3F3713A6149C24FA.yaml
+++ b/SaltySD/plugins/FPSLocker/patches/0100D0B01C4F4002/3F3713A6149C24FA.yaml
@@ -3,36 +3,36 @@
 
 ALL_FPS:
   # Memoized result of the "FPSLimiter.FPS_NX" config-key resolver.
-  ## REF: 88 02 40 B9 1F 05 00 31 E0 00 00 54
+  ## REF: 88 02 40 B9 1F 05 00 31 E0 00 00 54, ADRP + ADD above
   -
     type: evaluate_write
     address: [MAIN, 0x149B7E8]
     value_type: int32
     value: FPS_LOCK_TARGET
-  # Dynamic resolution governor at MAIN+0x1BAAC28, pointer at MAIN+0x1482328
-  ## REF: 08 29 9C 52 48 EF A7 72 01 01 27 1E A9 99
+  # Dynamic resolution governor
+  ## REF: 08 29 9C 52 48 EF A7 72 01 01 27 1E A9 99, first ADRP + LDR below gets base address
   # budget
   -
     type: evaluate_write
-    address: [MAIN, 0x1BAADF8]
+    address: [MAIN, 0x1BAADF8] # base + 0x1D0
     value_type: float
     value: "floor(FRAMETIME_TARGET * 0.98)"
   # slow-frame threshold
   -
     type: evaluate_write
-    address: [MAIN, 0x1BAADFC]
+    address: [MAIN, 0x1BAADFC] # base + 0x1D4
     value_type: float
     value: "floor(floor(FRAMETIME_TARGET * 0.98) * 1.29 + 1.05)"
   # band offset
   -
     type: evaluate_write
-    address: [MAIN, 0x1BAAE14]
+    address: [MAIN, 0x1BAAE14] # base + 0x1EC
     value_type: float
     value: "floor(FRAMETIME_TARGET * 0.98) * 0.05"
   # band half-width
   -
     type: evaluate_write
-    address: [MAIN, 0x1BAAE18]
+    address: [MAIN, 0x1BAAE18] # base + 0x1F0
     value_type: float
     value: "floor(FRAMETIME_TARGET * 0.98) * 0.025"
   -

--- a/SaltySD/plugins/FPSLocker/patches/0100D0B01C4F4002/3F3713A6149C24FA.yaml
+++ b/SaltySD/plugins/FPSLocker/patches/0100D0B01C4F4002/3F3713A6149C24FA.yaml
@@ -1,0 +1,40 @@
+# METAL GEAR SOLID 4: Guns of the Patriots - Master Collection Version 1.4.1
+# BID: 3F3713A6149C24FA
+
+ALL_FPS:
+  # Memoized result of the "FPSLimiter.FPS_NX" config-key resolver.
+  ## REF: 88 02 40 B9 1F 05 00 31 E0 00 00 54
+  -
+    type: evaluate_write
+    address: [MAIN, 0x149B7E8]
+    value_type: int32
+    value: FPS_LOCK_TARGET
+  # Dynamic resolution governor at MAIN+0x1BAAC28, pointer at MAIN+0x1482328
+  ## REF: 08 29 9C 52 48 EF A7 72 01 01 27 1E A9 99
+  # budget
+  -
+    type: evaluate_write
+    address: [MAIN, 0x1BAADF8]
+    value_type: float
+    value: "floor(FRAMETIME_TARGET * 0.98)"
+  # slow-frame threshold
+  -
+    type: evaluate_write
+    address: [MAIN, 0x1BAADFC]
+    value_type: float
+    value: "floor(floor(FRAMETIME_TARGET * 0.98) * 1.29 + 1.05)"
+  # band offset
+  -
+    type: evaluate_write
+    address: [MAIN, 0x1BAAE14]
+    value_type: float
+    value: "floor(FRAMETIME_TARGET * 0.98) * 0.05"
+  # band half-width
+  -
+    type: evaluate_write
+    address: [MAIN, 0x1BAAE18]
+    value_type: float
+    value: "floor(FRAMETIME_TARGET * 0.98) * 0.025"
+  -
+    type: block
+    what: timing


### PR DESCRIPTION
Tested on a Switch Lite (handheld, stock clocks, SaltyNX 1.9.2 + FPSLocker 3.3.2). All targets 35-60 lock; 60 holds outside heavy scenes, where the game becomes single-core bound.

DR retunes with the target — verified on hardware, same scene, only the target changed: 1280x720 at 30, 1056x594 at 60.

REF included for both sites, as asked.
